### PR TITLE
Add mslp in units pa

### DIFF
--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -120,7 +120,7 @@ module fv_diagnostics_mod
  integer :: yr_init, mo_init, dy_init, hr_init, mn_init, sec_init
  integer :: id_dx, id_dy
 
- real              :: vrange(2), vsrange(2), wrange(2), trange(2), slprange(2), rhrange(2), psrange(2), skrange(2)
+ real              :: vrange(2), vsrange(2), wrange(2), trange(2), slprange(2), slprangePa(2), rhrange(2), psrange(2), skrange(2)
 
  ! integer :: id_d_grid_ucomp, id_d_grid_vcomp   ! D grid winds
  ! integer :: id_c_grid_ucomp, id_c_grid_vcomp   ! C grid winds
@@ -215,6 +215,7 @@ contains
     trange = (/  100.,  350. /)  ! temperature
 #endif
     slprange = (/800.,  1200./)  ! sea-level-pressure
+    slprangePa = (/  80000.,  120000. /)  ! sea-level-pressure (Pa)
     skrange  = (/ -10000000.0,  10000000.0 /)  ! dissipation estimate for SKEB
 #ifdef SW_DYNAMICS
     psrange = (/.01, 1.e7 /)
@@ -911,7 +912,7 @@ contains
                                       range=slprange )
        id_slp_pa = register_diag_field (trim(field), 'slp_Pa', axes(1:2),  Time,   &
                                      'sea-level pressure', 'Pa', missing_value=missing_value,  &
-                                      range=slprange )
+                                      range=slprangePa )
 !----------------------------------
 ! Bottom level pressure for masking
 !----------------------------------

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -906,8 +906,11 @@ contains
 !-------------------
 ! Sea-level-pressure
 !-------------------
-       id_slp = register_diag_field (trim(field), 'slp', axes(1:2),  Time,   &
+       id_slp = register_diag_field (trim(field), 'slp_hPa', axes(1:2),  Time,   &
                                      'sea-level pressure', 'mb', missing_value=missing_value,  &
+                                      range=slprange )
+       id_slp_pa = register_diag_field (trim(field), 'slp_Pa', axes(1:2),  Time,   &
+                                     'sea-level pressure', 'Pa', missing_value=missing_value,  &
                                       range=slprange )
 !----------------------------------
 ! Bottom level pressure for masking
@@ -1541,7 +1544,7 @@ contains
 
     real, allocatable :: a2(:,:),a3(:,:,:),a4(:,:,:), wk(:,:,:), wz(:,:,:), ucoor(:,:,:), vcoor(:,:,:)
     real, allocatable :: ustm(:,:), vstm(:,:)
-    real, allocatable :: slp(:,:), depress(:,:), ws_max(:,:), tc_count(:,:)
+    real, allocatable :: slp(:,:), slp_pa(:,:), depress(:,:), ws_max(:,:), tc_count(:,:)
     real, allocatable :: u2(:,:), v2(:,:), x850(:,:), var1(:,:), var2(:,:), var3(:,:)
     real, allocatable :: dmmr(:,:,:), dvmr(:,:,:)
     real height(2)
@@ -2290,7 +2293,7 @@ contains
 
 
 
-       if( id_slp>0 .or. id_tm>0 .or. id_any_hght>0 .or. id_hght3d>0 .or. id_c15>0 .or. id_ctz>0 ) then
+       if( id_slp>0 .or. id_slp_pa>0 .or. id_tm>0 .or. id_any_hght>0 .or. id_hght3d>0 .or. id_c15>0 .or. id_ctz>0 ) then
 
           allocate ( wz(isc:iec,jsc:jec,npz+1) )
           call get_height_field(isc, iec, jsc, jec, ngc, npz, Atm(n)%flagstruct%hydrostatic, Atm(n)%delz,  &
@@ -2302,35 +2305,42 @@ contains
              used = send_data(id_hght3d, 0.5*(wz(isc:iec,jsc:jec,1:npz)+wz(isc:iec,jsc:jec,2:npz+1)), Time)
           endif
 
+          if (id_slp_pa > 0) then
+            allocate ( slp_pa(isc:iec,jsc:jec) )
+            call get_pressure_given_height(isc, iec, jsc, jec, ngc, npz, wz, 1, height(2),   &
+                                        Atm(n)%pt(:,:,npz), Atm(n)%peln, slp_pa, 1.0)
+            used = send_data (id_slp_pa, slp_pa, Time)
+          end if
+
           if(id_slp > 0) then
 ! Cumpute SLP (pressure at height=0)
-          allocate ( slp(isc:iec,jsc:jec) )
-          call get_pressure_given_height(isc, iec, jsc, jec, ngc, npz, wz, 1, height(2),   &
+            allocate ( slp(isc:iec,jsc:jec) )
+            call get_pressure_given_height(isc, iec, jsc, jec, ngc, npz, wz, 1, height(2),   &
                                         Atm(n)%pt(:,:,npz), Atm(n)%peln, slp, 0.01)
 
-          if ( Atm(n)%flagstruct%range_warn ) then
-             call range_check('SLP', slp, isc, iec, jsc, jec, 0, Atm(n)%gridstruct%agrid,    &
+            if ( Atm(n)%flagstruct%range_warn ) then
+               call range_check('SLP', slp, isc, iec, jsc, jec, 0, Atm(n)%gridstruct%agrid,    &
                   slprange(1), slprange(2), bad_range, Time)
-          endif
-          used = send_data (id_slp, slp, Time)
-             if( prt_minmax ) then
-                call prt_mxm('SLP (Pa): ', slp, isc, iec, jsc, jec, 0, 1, 1., Atm(n)%gridstruct%area_64, Atm(n)%domain)
-                call prt_maxmin('SLP', slp, isc, iec, jsc, jec, 0, 1, 1.)
-                if ( .not. Atm(n)%gridstruct%bounded_domain ) then
+            endif
+            used = send_data (id_slp, slp, Time)
+               if( prt_minmax ) then
+                  call prt_mxm('SLP (Pa): ', slp, isc, iec, jsc, jec, 0, 1, 1., Atm(n)%gridstruct%area_64, Atm(n)%domain)
+                  call prt_maxmin('SLP', slp, isc, iec, jsc, jec, 0, 1, 1.)
+                  if ( .not. Atm(n)%gridstruct%bounded_domain ) then
 ! US Potential Landfall TCs (PLT):
-                 do j=jsc,jec
-                    do i=isc,iec
-                       a2(i,j) = 1015.
-                       slon = rad2deg*Atm(n)%gridstruct%agrid(i,j,1)
-                       slat = rad2deg*Atm(n)%gridstruct%agrid(i,j,2)
-                       if ( slat>15. .and. slat<40. .and. slon>270. .and. slon<290. ) then
+                     do j=jsc,jec
+                     do i=isc,iec
+                        a2(i,j) = 1015.
+                        slon = rad2deg*Atm(n)%gridstruct%agrid(i,j,1)
+                        slat = rad2deg*Atm(n)%gridstruct%agrid(i,j,2)
+                        if ( slat>15. .and. slat<40. .and. slon>270. .and. slon<290. ) then
                             a2(i,j) = slp(i,j)
-                       endif
-                    enddo
-                 enddo
-                 call prt_mxm('SLP_ATL (Pa): ', a2, isc, iec, jsc, jec, 0,   1, 1., Atm(n)%gridstruct%area_64, Atm(n)%domain)
-                endif
-             endif
+                        endif
+                     enddo
+                     enddo
+                     call prt_mxm('SLP_ATL (Pa): ', a2, isc, iec, jsc, jec, 0,   1, 1., Atm(n)%gridstruct%area_64, Atm(n)%domain)
+                  endif
+               endif
           endif
 
 ! Compute H3000 and/or H500
@@ -2516,6 +2526,7 @@ contains
             endif
 
             if(id_slp>0 )  deallocate( slp )
+            if(id_slp_pa>0 )  deallocate( slp_pa )
 
            deallocate( a3 ) !needed because a3 may need to be re-allocated later with a different number of vertical levels
         endif

--- a/tools/fv_diagnostics.h
+++ b/tools/fv_diagnostics.h
@@ -22,7 +22,7 @@
 #ifndef _FV_DIAG__
 #define _FV_DIAG__
 
- integer ::id_ps, id_slp, id_ua, id_va, id_pt, id_omga, id_vort,  &
+ integer ::id_ps, id_slp, id_slp_pa, id_ua, id_va, id_pt, id_omga, id_vort,  &
       id_tm, id_pv, id_zsurf, id_oro, id_sgh, id_w, &
            id_ke, id_zs, id_ze, id_mq, id_vorts, id_us, id_vs,    &
            id_tq, id_rh, id_c15, id_c25, id_c35, id_c45,          &


### PR DESCRIPTION
**Description**
Adds support to write out mean sea level pressure in Pa. The new and old variables are available as 
```
"dynamics",  "slp_Pa",      "PRMSL",      "atmos_sos", "all", .false., "none", 2
"dynamics",  "slp_hPa",     "PRMSLhPa",    "atmos_sos", "all", .false., "none", 2
```
in the diag_table. The slp in hPa was previously named `slp`.

**How Has This Been Tested?**
The test is briefly described with outcome here:
https://github.com/wavespotter/esm-box/pull/55


**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
